### PR TITLE
Move to rstml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,59 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.70"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "autocfg"
@@ -19,12 +68,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "cc"
@@ -40,51 +83,62 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.11"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
 dependencies = [
- "bitflags 2.0.2",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.9"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -98,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -153,13 +207,13 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -223,9 +277,9 @@ checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
 name = "insta"
-version = "1.28.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea5b3894afe466b4bcf0388630fc15e11938a6074af0cd637c825ba2ec8a099"
+checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
 dependencies = [
  "console",
  "lazy_static",
@@ -236,25 +290,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -286,9 +340,9 @@ dependencies = [
  "leptosfmt-prettyplease",
  "proc-macro2",
  "quote",
+ "rstml",
  "serde",
  "syn 2.0.18",
- "syn-rsx",
  "thiserror",
 ]
 
@@ -315,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "linked-hash-map"
@@ -327,9 +381,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "memchr"
@@ -358,15 +412,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro-error"
@@ -394,11 +442,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -433,17 +494,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.36.11"
+name = "rstml"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "d7afcc74cab5d3118523b1f75900e1fcbeae7cac6c6cb800430621bf58add0bd"
 dependencies = [
- "bitflags 1.3.2",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.18",
+ "syn_derive",
+ "thiserror",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -454,18 +529,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -506,7 +581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -522,23 +596,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-rsx"
-version = "0.9.0"
-source = "git+https://github.com/dgsantana/syn-rsx.git?branch=update_syn#c6ebe8280d392b091231168b602bd2571ae04f06"
+name = "syn_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8128874d02f9a114ade6d9ad252078cb32d3cb240e26477ac73d7e9c495c605e"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.18",
- "thiserror",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -597,9 +663,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
@@ -608,58 +680,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -668,13 +703,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -684,10 +734,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -696,10 +758,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -708,16 +782,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
@@ -736,3 +828,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/formatter/Cargo.toml
+++ b/formatter/Cargo.toml
@@ -9,7 +9,7 @@ description = "view macro formatter for the Leptos web framework"
 
 [dependencies]
 leptosfmt-pretty-printer.workspace = true
-syn-rsx = { git = "https://github.com/dgsantana/syn-rsx.git", branch = "update_syn" }
+rstml = "0.10.6"
 syn = { version = "2.0.18", features = [ "visit", "full", "extra-traits" ] }
 leptosfmt-prettyplease = { features = [ "verbatim" ], version = "0.2.11" }
 proc-macro2 = { version = "1.0.52", features = [ "span-locations" ] }

--- a/formatter/src/formatter/attribute.rs
+++ b/formatter/src/formatter/attribute.rs
@@ -1,4 +1,4 @@
-use rstml::node::{NodeAttribute, KeyedAttribute};
+use rstml::node::{KeyedAttribute, NodeAttribute};
 use syn::Expr;
 
 use crate::{formatter::Formatter, AttributeValueBraceStyle as Braces};

--- a/formatter/src/formatter/attribute.rs
+++ b/formatter/src/formatter/attribute.rs
@@ -1,19 +1,27 @@
-use syn_rsx::{NodeAttribute, NodeValueExpr};
+use rstml::node::{NodeAttribute, KeyedAttribute};
+use syn::Expr;
 
 use crate::{formatter::Formatter, AttributeValueBraceStyle as Braces};
 
 impl Formatter<'_> {
     pub fn attribute(&mut self, attribute: &NodeAttribute) {
+        match attribute {
+            NodeAttribute::Attribute(k) => self.keyed_attribute(k),
+            NodeAttribute::Block(b) => self.node_block(b),
+        }
+    }
+
+    pub fn keyed_attribute(&mut self, attribute: &KeyedAttribute) {
         self.node_name(&attribute.key);
 
-        if let Some(value) = &attribute.value {
+        if let Some(value) = attribute.value() {
             self.printer.word("=");
             self.attribute_value(value);
         }
     }
 
-    fn attribute_value(&mut self, value: &NodeValueExpr) {
-        match (self.settings.attr_value_brace_style, value.as_ref()) {
+    fn attribute_value(&mut self, value: &Expr) {
+        match (self.settings.attr_value_brace_style, value) {
             (Braces::Always, syn::Expr::Block(_)) => self.node_value_expr(value, false, false),
             (Braces::AlwaysUnlessLit, syn::Expr::Block(_) | syn::Expr::Lit(_)) => {
                 self.node_value_expr(value, false, true)

--- a/formatter/src/formatter/element.rs
+++ b/formatter/src/formatter/element.rs
@@ -1,4 +1,4 @@
-use rstml::node::{Node, NodeElement, NodeAttribute};
+use rstml::node::{Node, NodeAttribute, NodeElement};
 
 use crate::formatter::Formatter;
 
@@ -129,7 +129,7 @@ fn is_void_element(name: &str, has_children: bool) -> bool {
 mod tests {
     use crate::{
         formatter::FormatterSettings,
-        test_helpers::{element, format_with},
+        test_helpers::{element, element_from_string, format_with},
     };
 
     macro_rules! format_element {
@@ -138,6 +138,19 @@ mod tests {
             format_with(FormatterSettings { max_width: 40, ..Default::default() }, |formatter| {
                 formatter.element(&element)
             })
+        }};
+    }
+    macro_rules! fromat_element_from_string {
+        ($val:expr) => {{
+            let element = element_from_string! { $val };
+
+            format_with(
+                FormatterSettings {
+                    max_width: 40,
+                    ..Default::default()
+                },
+                |formatter| formatter.element(&element),
+            )
         }};
     }
 
@@ -225,5 +238,27 @@ mod tests {
             ". Increment by one is this: " {count + 1}
         </div>
         "###);
+    }
+
+    #[test]
+    fn html_unquoted_text2() {
+        let formatted = fromat_element_from_string!(r##"<div> Unquoted text with  spaces </div>"##);
+        insta::assert_snapshot!(formatted, @r#"
+        <div>
+            Unquoted text with  spaces
+        </div>"#);
+    }
+
+    #[test]
+    fn html_unquoted_text_multiline() {
+        let formatted = fromat_element_from_string!(
+            r##"<div> Unquoted text
+            with  spaces </div>"##
+        );
+        insta::assert_snapshot!(formatted, @r###"
+        <div>
+            Unquoted text
+                    with  spaces
+        </div>"###);
     }
 }

--- a/formatter/src/formatter/element.rs
+++ b/formatter/src/formatter/element.rs
@@ -1,24 +1,24 @@
-use syn_rsx::{Node, NodeElement};
+use rstml::node::{Node, NodeElement, NodeAttribute};
 
 use crate::formatter::Formatter;
 
 impl Formatter<'_> {
     pub fn element(&mut self, element: &NodeElement) {
-        let name = element.name.to_string();
+        let name = element.name().to_string();
         let is_void = is_void_element(&name, !element.children.is_empty());
         self.opening_tag(element, is_void);
 
         if !is_void {
-            self.children(&element.children, element.attributes.len());
+            self.children(&element.children, element.attributes().len());
             self.closing_tag(element)
         }
     }
 
     fn opening_tag(&mut self, element: &NodeElement, is_void: bool) {
         self.printer.word("<");
-        self.node_name(&element.name);
+        self.node_name(&element.name());
 
-        self.attributes(&element.attributes);
+        self.attributes(element.attributes());
 
         if is_void {
             self.printer.word("/>");
@@ -29,25 +29,25 @@ impl Formatter<'_> {
 
     fn closing_tag(&mut self, element: &NodeElement) {
         self.printer.word("</");
-        self.node_name(&element.name);
+        self.node_name(element.name());
         self.printer.word(">")
     }
 
-    fn attributes(&mut self, attributes: &Vec<Node>) {
+    fn attributes(&mut self, attributes: &[NodeAttribute]) {
         if attributes.is_empty() {
             return;
         }
 
-        if let [attribute] = attributes.as_slice() {
+        if let [attribute] = attributes {
             self.printer.nbsp();
-            self.node(attribute);
+            self.attribute(attribute);
         } else {
             self.printer.cbox_indent();
             self.printer.space();
 
             let mut iter = attributes.iter().peekable();
             while let Some(attr) = iter.next() {
-                self.node(attr);
+                self.attribute(attr);
 
                 if iter.peek().is_some() {
                     self.printer.space()

--- a/formatter/src/formatter/expr.rs
+++ b/formatter/src/formatter/expr.rs
@@ -4,8 +4,10 @@ use crate::{formatter::Formatter, view_macro::ViewMacroFormatter};
 
 impl Formatter<'_> {
     pub fn literal_str(&mut self, string: &LitStr) {
-        let val = format!("\"{}\"", string.value());
-        self.printer.word(val);
+        self.expr(&Expr::Lit(ExprLit {
+            attrs: vec![],
+            lit: syn::Lit::Str(string.clone()),
+        }));
     }
 
     pub fn node_value_block(

--- a/formatter/src/formatter/fragment.rs
+++ b/formatter/src/formatter/fragment.rs
@@ -1,4 +1,4 @@
-use syn_rsx::NodeFragment;
+use rstml::node::NodeFragment;
 
 use crate::formatter::Formatter;
 

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -1,7 +1,7 @@
 use leptosfmt_pretty_printer::Printer;
 use proc_macro2::{token_stream, Span, TokenStream, TokenTree};
 use syn::{spanned::Spanned, Macro};
-use syn_rsx::Node;
+use rstml::node::Node;
 
 use super::{Formatter, FormatterSettings};
 
@@ -20,7 +20,7 @@ impl<'a> ViewMacro<'a> {
         let (Some(cx), Some(_comma)) = (tokens.next(), tokens.next()) else { return None; };
 
         let Some((tokens, global_class)) = extract_global_class(tokens) else { return None; };
-        let nodes = syn_rsx::parse2(tokens).ok()?;
+        let nodes = rstml::parse2(tokens).ok()?;
 
         Some(Self {
             parent_ident,

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -1,7 +1,7 @@
 use leptosfmt_pretty_printer::Printer;
 use proc_macro2::{token_stream, Span, TokenStream, TokenTree};
-use syn::{spanned::Spanned, Macro};
 use rstml::node::Node;
+use syn::{spanned::Spanned, Macro};
 
 use super::{Formatter, FormatterSettings};
 

--- a/formatter/src/formatter/node.rs
+++ b/formatter/src/formatter/node.rs
@@ -33,10 +33,9 @@ impl Formatter<'_> {
 
     pub fn raw_text(&mut self, text: &RawText, use_source_text: bool) {
         let text = if use_source_text {
-            text.to_source_text(true)
+            text.to_source_text(false)
                 .expect("Cannot format unquoted text, no source text available, or unquoted text is used outside of element.")
-        }
-        else {
+        } else {
             text.to_token_stream_string()
         };
         // TODO: can convert it to quoted if need

--- a/formatter/src/formatter/node.rs
+++ b/formatter/src/formatter/node.rs
@@ -1,4 +1,4 @@
-use syn_rsx::{Node, NodeBlock, NodeComment, NodeDoctype, NodeName, NodeText};
+use rstml::node::{Node, NodeBlock, NodeComment, NodeDoctype, NodeName, NodeText, RawText};
 
 use crate::formatter::Formatter;
 
@@ -6,8 +6,8 @@ impl Formatter<'_> {
     pub fn node(&mut self, node: &Node) {
         match node {
             Node::Element(ele) => self.element(ele),
-            Node::Attribute(attr) => self.attribute(attr),
             Node::Text(text) => self.node_text(text),
+            Node::RawText(text) => self.raw_text(text, true),
             Node::Comment(comment) => self.comment(comment),
             Node::Doctype(doctype) => self.doctype(doctype),
             Node::Block(block) => self.node_block(block),
@@ -17,18 +17,30 @@ impl Formatter<'_> {
 
     pub fn comment(&mut self, comment: &NodeComment) {
         self.printer.word("<!-- ");
-        self.node_value_expr(&comment.value, false, false);
+        self.literal_str(&comment.value);
         self.printer.word(" -->");
     }
 
     pub fn doctype(&mut self, doctype: &NodeDoctype) {
         self.printer.word("<!DOCTYPE ");
-        self.node_value_expr(&doctype.value, false, false);
+        self.raw_text(&doctype.value, false);
         self.printer.word("> ");
     }
 
     pub fn node_text(&mut self, text: &NodeText) {
-        self.node_value_expr(&text.value, false, false);
+        self.literal_str(&text.value);
+    }
+
+    pub fn raw_text(&mut self, text: &RawText, use_source_text: bool) {
+        let text = if use_source_text {
+            text.to_source_text(true)
+                .expect("Cannot format unquoted text, no source text available, or unquoted text is used outside of element.")
+        }
+        else {
+            text.to_token_stream_string()
+        };
+        // TODO: can convert it to quoted if need
+        self.printer.word(text)
     }
 
     pub fn node_name(&mut self, name: &NodeName) {
@@ -36,7 +48,10 @@ impl Formatter<'_> {
     }
 
     pub fn node_block(&mut self, block: &NodeBlock) {
-        self.node_value_expr(&block.value, false, false);
+        match block {
+            NodeBlock::Invalid { .. } => panic!("Invalid block will not pass cargo check"), // but we can keep them instead of panic
+            NodeBlock::ValidBlock(b) => self.node_value_block(b, false, false),
+        }
     }
 }
 

--- a/formatter/src/test_helpers.rs
+++ b/formatter/src/test_helpers.rs
@@ -1,11 +1,11 @@
 use leptosfmt_pretty_printer::Printer;
-use syn_rsx::{Node, NodeAttribute, NodeComment, NodeDoctype, NodeElement, NodeFragment};
+use rstml::node::{Node, NodeAttribute, NodeComment, NodeDoctype, NodeElement, NodeFragment};
 
 macro_rules! attribute {
     ($($tt:tt)*) => {
         {
         let tokens = quote::quote! { <tag $($tt)* /> };
-        let nodes = syn_rsx::parse2(tokens).unwrap();
+        let nodes = rstml::parse2(tokens).unwrap();
         crate::test_helpers::get_element_attribute(nodes, 0, 0)
     }};
 }
@@ -14,7 +14,7 @@ macro_rules! element {
     ($($tt:tt)*) => {
         {
         let tokens = quote::quote! { $($tt)* };
-        let nodes = syn_rsx::parse2(tokens).unwrap();
+        let nodes = rstml::parse2(tokens).unwrap();
         crate::test_helpers::get_element(nodes, 0)
     }};
 }
@@ -23,7 +23,7 @@ macro_rules! fragment {
     ($($tt:tt)*) => {
         {
         let tokens = quote::quote! { $($tt)* };
-        let nodes = syn_rsx::parse2(tokens).unwrap();
+        let nodes = rstml::parse2(tokens).unwrap();
         crate::test_helpers::get_fragment(nodes, 0)
     }};
 }
@@ -32,7 +32,7 @@ macro_rules! comment {
     ($($tt:tt)*) => {
         {
         let tokens = quote::quote! { $($tt)* };
-        let nodes = syn_rsx::parse2(tokens).unwrap();
+        let nodes = rstml::parse2(tokens).unwrap();
         crate::test_helpers::get_comment(nodes, 0)
     }};
 }
@@ -41,7 +41,7 @@ macro_rules! doctype {
     ($($tt:tt)*) => {
         {
         let tokens = quote::quote! { $($tt)* };
-        let nodes = syn_rsx::parse2(tokens).unwrap();
+        let nodes = rstml::parse2(tokens).unwrap();
         crate::test_helpers::get_doctype(nodes, 0)
     }};
 }
@@ -59,12 +59,13 @@ pub fn get_element_attribute(
     element_index: usize,
     attribute_index: usize,
 ) -> NodeAttribute {
-    let Node::Element(mut element) =
+    let Node::Element(element) =
         nodes.swap_remove(element_index) else { panic!("expected element") };
-    let Node::Attribute(attribute) =
-        element.attributes.swap_remove(attribute_index) else { panic!("expected attribute") };
-
-    attribute
+    element
+        .attributes()
+        .get(attribute_index)
+        .expect("attribute exist")
+        .clone()
 }
 
 pub fn get_element(mut nodes: Vec<Node>, element_index: usize) -> NodeElement {

--- a/formatter/src/test_helpers.rs
+++ b/formatter/src/test_helpers.rs
@@ -19,6 +19,18 @@ macro_rules! element {
     }};
 }
 
+// Same as element, but use string representation of token stream.
+// This is usefull when testing unquoted text,
+// because current `quote!` implementation cannot provide `Span::source_text`
+// that is used in `raw_text` handler
+macro_rules! element_from_string {
+    ($val: expr) => {{
+        let tokens = <proc_macro2::TokenStream as std::str::FromStr>::from_str($val).unwrap();
+        let nodes = rstml::parse2(tokens).unwrap();
+        crate::test_helpers::get_element(nodes, 0)
+    }};
+}
+
 macro_rules! fragment {
     ($($tt:tt)*) => {
         {
@@ -50,6 +62,7 @@ pub(crate) use attribute;
 pub(crate) use comment;
 pub(crate) use doctype;
 pub(crate) use element;
+pub(crate) use element_from_string;
 pub(crate) use fragment;
 
 use crate::{Formatter, FormatterSettings};


### PR DESCRIPTION
Hi, this PR move from syn-rsx to rstml.

Currently most of changes in rstml is aimed to support recoverable parser, and there is not a lot of new syntax features.

One notable feature, is `unquoted text` aka [`RawText` in rstml](https://docs.rs/rstml/0.10.6/rstml/node/struct.RawText.html).
Under the hood it use `Span::source_text` and `Span::join` to retrieve space information and therefore depend on nightly. (it work on stable, but will mess spaces).

In this pr i have added basic support of raw_text node, and added tests just to snapshot current situation.
But, because i am not familiar with leptosfmt code, i couldn't tweak it to fmt unquoted text as it was in html formatter.
Currently it adds indentations, preserve spaces in text, but will completely ignore whitespaces before and after text.

If i understand correctly, in HTML, at least one space before and after text are meaningful, and we probably should save them, but i am not sure about that.

Anyway if this behavior should be changed, `RawText` api allows to save whitespaces. https://docs.rs/rstml/0.10.6/rstml/node/struct.RawText.html#method.to_source_text.
