### PR TITLE
fix: implement workaround for non-doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [0.1.10] - 2023-07-22
 
 ### Bug Fixes
 
-- Rework doc comments ([#48](https://github.com/bram209/leptosfmt/issues/48))
+- Rework non-doc comments ([#48](https://github.com/bram209/leptosfmt/issues/48))
 
 ### Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leptosfmt"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "leptosfmt-formatter"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "crop",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 members = ["printer", "cli", "formatter"]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-leptosfmt-formatter = { path = "./formatter", version = "0.1.9" }
+leptosfmt-formatter = { path = "./formatter", version = "0.1.10" }
 leptosfmt-pretty-printer = { version = "0.1.6" }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Options:
   -V, --version                  Print version
 ```
 
+## Known issues
+
+- **End of line** non-doc comments (with two forward slashes) are not yet supported.
+
 ## Configuration
 You can configure all settings through a `leptosfmt.toml` file.
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -62,7 +62,7 @@ filter_commits = true
 # glob pattern for matching git tags
 tag_pattern = "[0-9]*"
 # regex for skipping tags
-skip_tags = "0.1.[1-2]"
+skip_tags = "0.1.0"
 # regex for ignoring tags
 ignore_tags = ""
 # sort the tags topologically

--- a/formatter/src/formatter/element.rs
+++ b/formatter/src/formatter/element.rs
@@ -15,7 +15,7 @@ impl Formatter<'_> {
 
     fn opening_tag(&mut self, element: &NodeElement, is_void: bool) {
         self.tokens(&element.open_tag.token_lt);
-        self.visit_span(&element.open_tag.name);
+        self.visit_spanned(&element.open_tag.name);
         self.node_name(&element.open_tag.name);
 
         self.attributes(element.attributes());
@@ -25,11 +25,11 @@ impl Formatter<'_> {
         } else {
             self.printer.word(">")
         }
-        self.visit_span(&element.open_tag.end_tag);
+        self.visit_spanned(&element.open_tag.end_tag);
     }
 
     fn closing_tag(&mut self, element: &NodeElement) {
-        self.visit_span(&element.close_tag);
+        self.visit_spanned(&element.close_tag);
         self.printer.word("</");
         self.node_name(element.name());
         self.printer.word(">");
@@ -43,7 +43,7 @@ impl Formatter<'_> {
         if let [attribute] = attributes {
             self.printer.cbox(0);
             self.printer.nbsp();
-            self.visit_span(attribute);
+            self.visit_spanned(attribute);
             self.attribute(attribute);
             self.printer.end();
         } else {
@@ -52,7 +52,7 @@ impl Formatter<'_> {
 
             let mut iter = attributes.iter().peekable();
             while let Some(attr) = iter.next() {
-                self.visit_span(attr);
+                self.visit_spanned(attr);
                 self.attribute(attr);
 
                 if iter.peek().is_some() {

--- a/formatter/src/formatter/fragment.rs
+++ b/formatter/src/formatter/fragment.rs
@@ -4,11 +4,11 @@ use crate::formatter::Formatter;
 
 impl Formatter<'_> {
     pub fn fragment(&mut self, fragment: &NodeFragment) {
-        self.visit_span(&fragment.tag_open);
+        self.visit_spanned(&fragment.tag_open);
         self.printer.word("<>");
         self.children(&fragment.children, 0);
         self.printer.word("</>");
-        self.visit_span(&fragment.tag_close);
+        self.visit_spanned(&fragment.tag_close);
     }
 }
 

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -58,7 +58,7 @@ impl Formatter<'_> {
 
         self.printer.cbox(indent as isize);
 
-        self.visit_span(view_mac.mac.bang_token);
+        self.visit_spanned(view_mac.mac.bang_token);
         self.printer.word("view! { ");
         self.printer.word(cx.to_string());
         self.tokens(&comma);
@@ -70,6 +70,7 @@ impl Formatter<'_> {
         }
 
         self.view_macro_nodes(nodes);
+        self.visit_span(view_mac.mac.delimiter.span().close());
         self.printer.word("}");
         self.printer.end();
     }

--- a/formatter/src/formatter/node.rs
+++ b/formatter/src/formatter/node.rs
@@ -17,7 +17,7 @@ impl Formatter<'_> {
 
         match node {
             Node::Element(_) | Node::Fragment(_) => {}
-            _ => self.visit_span(node),
+            _ => self.visit_spanned(node),
         }
     }
 

--- a/formatter/src/source_file.rs
+++ b/formatter/src/source_file.rs
@@ -101,6 +101,36 @@ mod tests {
 
     #[test]
     fn with_comments() {
+        // let source = indoc! {r#"
+        //     // comment outside view macro
+        //     fn main() {
+        //         view! {   cx ,
+        //             // Top level comment
+        //             <div>
+        //                 // This is one beautiful message
+        //             <span>"hello"</span> // at the end of the line 1
+        //             <div>// at the end of the line 2
+        //      // double
+        //      // comments
+        //             <span>"hello"</span> </div>
+        //              <For
+        //     // a function that returns the items we're iterating over; a signal is fine
+        //     each= move || {errors.clone().into_iter().enumerate()}
+        //     // a unique key for each item as a reference
+        //      key=|(index, _error)| *index // yeah
+        //      />
+        //      <div> // same line comment
+        //      // with comment on the next line
+        //      </div>
+        //      // comments with empty lines inbetween
+
+        //      // and some more
+        //      // on the next line
+        //             </div>  };
+        //     }
+
+        //     // comment after view macro
+        // "#};
         let source = indoc! {r#"
             // comment outside view macro
             fn main() {
@@ -108,8 +138,8 @@ mod tests {
                     // Top level comment
                     <div>  
                         // This is one beautiful message
-                    <span>"hello"</span> // at the end of the line 1
-                    <div>// at the end of the line 2
+                    <span>"hello"</span> 
+                    <div>
              // double
              // comments
                     <span>"hello"</span> </div>
@@ -117,9 +147,9 @@ mod tests {
             // a function that returns the items we're iterating over; a signal is fine
             each= move || {errors.clone().into_iter().enumerate()}
             // a unique key for each item as a reference
-             key=|(index, _error)| *index // yeah
+             key=|(index, _error)| *index 
              />
-             <div> // same line comment
+             <div> 
              // with comment on the next line
              </div>
              // comments with empty lines inbetween
@@ -140,9 +170,7 @@ mod tests {
                 // Top level comment
                 <div>
                     // This is one beautiful message
-                    // at the end of the line 1
                     <span>"hello"</span>
-                    // at the end of the line 2
                     <div>
                         // double
                         // comments
@@ -152,10 +180,8 @@ mod tests {
                         // a function that returns the items we're iterating over; a signal is fine
                         each=move || { errors.clone().into_iter().enumerate() }
                         // a unique key for each item as a reference
-                        // yeah
                         key=|(index, _error)| *index
                     />
-                    // same line comment
                     <div>// with comment on the next line
                     </div>
                 // comments with empty lines inbetween
@@ -209,10 +235,10 @@ mod tests {
             fn main() {
                 view! {   cx ,  
                     // parent div
-                    <div>  
+                    <div> 
 
                     // parent span
-                    <span>{
+                    <span>{ //ok
                         let a = 12;
 
                         view! { cx,             


### PR DESCRIPTION
note: this removes support for formatting end-of-line comments.
will fix in later PR