### PR TITLE
feat: rework non-doc comments v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Options:
   -V, --version                  Print version
 ```
 
-## Known issues
-
-- **End of line** non-doc comments (with two forward slashes) are not yet supported.
-
 ## Configuration
 You can configure all settings through a `leptosfmt.toml` file.
 

--- a/formatter/src/collect.rs
+++ b/formatter/src/collect.rs
@@ -60,7 +60,7 @@ impl<'ast> Visit<'ast> for ViewMacroVisitor<'ast> {
     }
 }
 
-pub fn collect_macros_in_file(file: &File) -> Vec<ViewMacro> {
+pub fn collect_macros_in_file(file: &File) -> Vec<ViewMacro<'_>> {
     let mut visitor = ViewMacroVisitor::default();
     visitor.visit_file(file);
     visitor.macros

--- a/formatter/src/collect_comments.rs
+++ b/formatter/src/collect_comments.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use crop::{Rope, RopeSlice};
+
+use proc_macro2::{LineColumn, Span, TokenStream, TokenTree};
+
+use crate::line_column_to_byte;
+
+pub(crate) fn extract_whitespace_and_comments(
+    source: &Rope,
+    tokens: TokenStream,
+) -> HashMap<usize, Option<String>> {
+    let mut whitespace_and_comments = HashMap::new();
+    let mut last_span: Option<Span> = None;
+
+    traverse_token_stream(tokens, &mut |token: &TokenTree| {
+        let span = token.span();
+        if let Some(last_span) = last_span {
+            if last_span.end().line != span.start().line {
+                let text = get_text_beween_spans(source, last_span.end(), span.start());
+                for (idx, line) in text.lines().enumerate() {
+                    let comment = line
+                        .to_string()
+                        .split("//")
+                        .nth(1)
+                        .map(str::trim)
+                        .map(ToOwned::to_owned);
+
+                    let line_index = last_span.end().line - 1 + idx;
+
+                    if comment.is_none()
+                        && (line_index == last_span.end().line - 1
+                            || line_index == span.start().line - 1)
+                    {
+                        continue;
+                    }
+
+                    whitespace_and_comments.insert(line_index, comment);
+                }
+            }
+        }
+        last_span = Some(span);
+    });
+
+    whitespace_and_comments
+}
+
+fn get_text_beween_spans(rope: &Rope, start: LineColumn, end: LineColumn) -> RopeSlice<'_> {
+    let start_byte = line_column_to_byte(rope, start);
+    let end_byte = line_column_to_byte(rope, end);
+
+    return rope.byte_slice(start_byte..end_byte);
+}
+
+fn traverse_token_stream(tokens: TokenStream, cb: &mut impl FnMut(&TokenTree)) {
+    for token in tokens {
+        match token {
+            proc_macro2::TokenTree::Group(group) => traverse_token_stream(group.stream(), cb),
+            _ => cb(&token),
+        }
+    }
+}

--- a/formatter/src/formatter/attribute.rs
+++ b/formatter/src/formatter/attribute.rs
@@ -1,10 +1,11 @@
 use rstml::node::{KeyedAttribute, NodeAttribute};
-use syn::Expr;
+use syn::{spanned::Spanned, Expr};
 
 use crate::{formatter::Formatter, AttributeValueBraceStyle as Braces};
 
 impl Formatter<'_> {
     pub fn attribute(&mut self, attribute: &NodeAttribute) {
+        self.flush_comments(attribute.span().start().line - 1);
         match attribute {
             NodeAttribute::Attribute(k) => self.keyed_attribute(k),
             NodeAttribute::Block(b) => self.node_block(b),
@@ -12,7 +13,6 @@ impl Formatter<'_> {
     }
 
     pub fn keyed_attribute(&mut self, attribute: &KeyedAttribute) {
-        self.visit_spanned(&attribute.key);
         self.node_name(&attribute.key);
 
         if let Some(value) = attribute.value() {

--- a/formatter/src/formatter/element.rs
+++ b/formatter/src/formatter/element.rs
@@ -1,5 +1,6 @@
 use crate::formatter::Formatter;
 use rstml::node::{Node, NodeAttribute, NodeElement};
+use syn::spanned::Spanned;
 
 impl Formatter<'_> {
     pub fn element(&mut self, element: &NodeElement) {
@@ -9,13 +10,13 @@ impl Formatter<'_> {
 
         if !is_void {
             self.children(&element.children, element.attributes().len());
+            self.flush_comments(element.close_tag.span().end().line - 1);
             self.closing_tag(element)
         }
     }
 
     fn opening_tag(&mut self, element: &NodeElement, is_void: bool) {
-        self.tokens(&element.open_tag.token_lt);
-        self.visit_spanned(&element.open_tag.name);
+        self.printer.word("<");
         self.node_name(&element.open_tag.name);
 
         self.attributes(element.attributes());
@@ -25,11 +26,9 @@ impl Formatter<'_> {
         } else {
             self.printer.word(">")
         }
-        self.visit_spanned(&element.open_tag.end_tag);
     }
 
     fn closing_tag(&mut self, element: &NodeElement) {
-        self.visit_spanned(&element.close_tag);
         self.printer.word("</");
         self.node_name(element.name());
         self.printer.word(">");

--- a/formatter/src/formatter/fragment.rs
+++ b/formatter/src/formatter/fragment.rs
@@ -4,11 +4,9 @@ use crate::formatter::Formatter;
 
 impl Formatter<'_> {
     pub fn fragment(&mut self, fragment: &NodeFragment) {
-        self.visit_spanned(&fragment.tag_open);
         self.printer.word("<>");
         self.children(&fragment.children, 0);
         self.printer.word("</>");
-        self.visit_spanned(&fragment.tag_close);
     }
 }
 

--- a/formatter/src/formatter/node.rs
+++ b/formatter/src/formatter/node.rs
@@ -5,6 +5,8 @@ use crate::formatter::Formatter;
 
 impl Formatter<'_> {
     pub fn node(&mut self, node: &Node) {
+        self.flush_comments(node.span().start().line - 1);
+
         match node {
             Node::Element(ele) => self.element(ele),
             Node::Fragment(frag) => self.fragment(frag),
@@ -14,11 +16,6 @@ impl Formatter<'_> {
             Node::Doctype(doctype) => self.doctype(doctype),
             Node::Block(block) => self.node_block(block),
         };
-
-        match node {
-            Node::Element(_) | Node::Fragment(_) => {}
-            _ => self.visit_spanned(node),
-        }
     }
 
     pub fn comment(&mut self, comment: &NodeComment) {

--- a/formatter/src/lib.rs
+++ b/formatter/src/lib.rs
@@ -4,6 +4,7 @@ use crop::Rope;
 pub use source_file::{format_file_source, FormatError};
 
 mod collect;
+mod collect_comments;
 mod formatter;
 mod source_file;
 mod view_macro;

--- a/formatter/src/source_file.rs
+++ b/formatter/src/source_file.rs
@@ -101,45 +101,15 @@ mod tests {
 
     #[test]
     fn with_comments() {
-        // let source = indoc! {r#"
-        //     // comment outside view macro
-        //     fn main() {
-        //         view! {   cx ,
-        //             // Top level comment
-        //             <div>
-        //                 // This is one beautiful message
-        //             <span>"hello"</span> // at the end of the line 1
-        //             <div>// at the end of the line 2
-        //      // double
-        //      // comments
-        //             <span>"hello"</span> </div>
-        //              <For
-        //     // a function that returns the items we're iterating over; a signal is fine
-        //     each= move || {errors.clone().into_iter().enumerate()}
-        //     // a unique key for each item as a reference
-        //      key=|(index, _error)| *index // yeah
-        //      />
-        //      <div> // same line comment
-        //      // with comment on the next line
-        //      </div>
-        //      // comments with empty lines inbetween
-
-        //      // and some more
-        //      // on the next line
-        //             </div>  };
-        //     }
-
-        //     // comment after view macro
-        // "#};
         let source = indoc! {r#"
             // comment outside view macro
             fn main() {
-                view! {   cx ,  
+                view! {   cx ,
                     // Top level comment
-                    <div>  
-                        // This is one beautiful message
-                    <span>"hello"</span> 
                     <div>
+                        // This is one beautiful message
+                    <span>"hello"</span> // at the end of the line 1
+                    <div>// at the end of the line 2
              // double
              // comments
                     <span>"hello"</span> </div>
@@ -147,16 +117,16 @@ mod tests {
             // a function that returns the items we're iterating over; a signal is fine
             each= move || {errors.clone().into_iter().enumerate()}
             // a unique key for each item as a reference
-             key=|(index, _error)| *index 
+             key=|(index, _error)| *index // yeah
              />
-             <div> 
+             <div> // same line comment
              // with comment on the next line
              </div>
              // comments with empty lines inbetween
 
              // and some more
              // on the next line
-                    </div>  }; 
+                    </div>  };
             }
 
             // comment after view macro
@@ -170,7 +140,9 @@ mod tests {
                 // Top level comment
                 <div>
                     // This is one beautiful message
+                    // at the end of the line 1
                     <span>"hello"</span>
+                    // at the end of the line 2
                     <div>
                         // double
                         // comments
@@ -180,8 +152,10 @@ mod tests {
                         // a function that returns the items we're iterating over; a signal is fine
                         each=move || { errors.clone().into_iter().enumerate() }
                         // a unique key for each item as a reference
+                        // yeah
                         key=|(index, _error)| *index
                     />
+                    // same line comment
                     <div>// with comment on the next line
                     </div>
                 // comments with empty lines inbetween
@@ -189,7 +163,7 @@ mod tests {
                 // and some more
                 // on the next line
                 </div>
-            }; 
+            };
         }
 
         // comment after view macro
@@ -202,6 +176,7 @@ mod tests {
             fn main() {
                 view! {   cx ,  <div>  <span>{
                         let a = 12;
+
 
                         view! { cx,             
                             
@@ -257,6 +232,7 @@ mod tests {
                 <div>
 
                     // parent span
+                    // ok
                     <span>
                         {
                             let a = 12;

--- a/formatter/src/test_helpers.rs
+++ b/formatter/src/test_helpers.rs
@@ -111,7 +111,9 @@ pub fn format_with_source(
 ) -> String {
     let mut printer = Printer::new((&settings).into());
     let rope = Rope::from_str(source).unwrap();
-    let mut formatter = Formatter::with_source(settings, &mut printer, &rope);
+    let tokens = <proc_macro2::TokenStream as std::str::FromStr>::from_str(source).unwrap();
+    let whitespace = crate::collect_comments::extract_whitespace_and_comments(&rope, tokens);
+    let mut formatter = Formatter::with_source(settings, &mut printer, &rope, whitespace);
     run(&mut formatter);
     printer.eof()
 }

--- a/formatter/src/view_macro.rs
+++ b/formatter/src/view_macro.rs
@@ -1,25 +1,29 @@
+use std::collections::HashMap;
+
 use crop::Rope;
 use leptosfmt_prettyplease::MacroFormatter;
-use proc_macro2::Span;
 
 use crate::{Formatter, FormatterSettings, ViewMacro};
 
 pub struct ViewMacroFormatter<'a> {
     settings: FormatterSettings,
     source: Option<&'a Rope>,
-    last_span: Option<Span>,
+    line_offset: Option<usize>,
+    comments: HashMap<usize, Option<String>>,
 }
 
 impl ViewMacroFormatter<'_> {
     pub fn new(
         settings: FormatterSettings,
         source: Option<&Rope>,
-        last_span: Option<Span>,
+        line_offset: Option<usize>,
+        comments: HashMap<usize, Option<String>>,
     ) -> ViewMacroFormatter<'_> {
         ViewMacroFormatter {
             settings,
             source,
-            last_span,
+            line_offset,
+            comments,
         }
     }
 }
@@ -35,7 +39,8 @@ impl MacroFormatter for ViewMacroFormatter<'_> {
             printer,
             settings: self.settings,
             source: self.source,
-            last_span: self.last_span,
+            line_offset: self.line_offset,
+            whitespace_and_comments: self.comments.clone(),
         };
 
         formatter.view_macro(&m);


### PR DESCRIPTION
Non-doc comments are comments that follow the general C++ style of line (`// ...`).

## Problem
The problem with non-doc comments is that they are interpreted as a form of whitespace.
This library is built on top of the `syn` library, which does not parse non-doc comments. In the previous version I tracked the spans of the original source code while traversing and formatting the abstract syntax tree simultaneously.

## New approach
This however proved to be an error prone approach. With the new approach, it iterates through the token stream twice: once to extract all whitespace (including non-doc comments) and another time to parse the HTML nodes with `rstml`.
During formatting the HTML nodes, the library then inserts the comments & whitespace where appropriate.

https://doc.rust-lang.org/reference/comments.html#non-doc-comments