### PR TITLE
feat: add indentation style (tabs/spaces) & newline style (LF/CRLF) settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,14 @@ edition = "2021"
 You can configure all settings through a `leptosfmt.toml` file.
 
 ```toml
-max_width = 100
-tab_spaces = 4
+max_width = 100 # Maximum width of each line
+tab_spaces = 4 # Number of spaces per tab
+indentation_style = "Auto" # "Tabs", "Spaces" or "Auto"
+newline_style = "Auto" # "Unix", "Windows" or "Auto"
 attr_value_brace_style = "WhenRequired" # "Always", "AlwaysUnlessLit", "WhenRequired" or "Preserve"
-
 ```
 
 To see what each setting does, the see [configuration docs](./docs/configuration.md)
-
-
 
 ## Examples
 

--- a/formatter/src/source_file.rs
+++ b/formatter/src/source_file.rs
@@ -79,6 +79,8 @@ fn format_source(
 mod tests {
     use indoc::indoc;
 
+    use crate::IndentationStyle;
+
     use super::*;
 
     #[test]
@@ -437,5 +439,109 @@ mod tests {
             }
         }
         "#);
+    }
+
+    #[test]
+    fn indent_with_tabs() {
+        let source = indoc! {"
+        fn main() {
+        \u{0020}view! { cx,
+              <div>
+                <div>Example</div>
+              </div>
+            }
+        }
+        "};
+
+        let result = format_file_source(
+            source,
+            FormatterSettings {
+                tab_spaces: 1,
+                indentation_style: IndentationStyle::Tabs,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let expected = indoc! {"
+        fn main() {
+        \u{0020}view! { cx,
+        \t\t<div>
+        \t\t\t<div>Example</div>
+        \t\t</div>
+        \t}
+        }
+        "};
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn auto_detect_tabs() {
+        let source = indoc! {"
+        fn main() {
+        \tview! { cx,
+              <div>
+                <div>Example</div>
+              </div>
+            }
+        }
+        "};
+
+        let result = format_file_source(
+            source,
+            FormatterSettings {
+                indentation_style: IndentationStyle::Auto,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let expected = indoc! {"
+        fn main() {
+        \tview! { cx,
+        \t\t<div>
+        \t\t\t<div>Example</div>
+        \t\t</div>
+        \t}
+        }
+        "};
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn auto_detect_spaces() {
+        let source = indoc! {"
+        fn main() {
+        \u{0020}view! { cx,
+              <div>
+                <div>Example</div>
+              </div>
+            }
+        }
+        "};
+
+        let result = format_file_source(
+            source,
+            FormatterSettings {
+                tab_spaces: 1,
+                indentation_style: IndentationStyle::Auto,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let expected = indoc! {"
+        fn main() {
+        \u{0020}view! { cx,
+        \u{0020}\u{0020}<div>
+        \u{0020}\u{0020}\u{0020}<div>Example</div>
+        \u{0020}\u{0020}</div>
+        \u{0020}}
+        }
+        "};
+
+        assert_eq!(result, expected);
     }
 }

--- a/formatter/src/test_helpers.rs
+++ b/formatter/src/test_helpers.rs
@@ -118,8 +118,8 @@ pub fn format_with_source(
     source: &str,
     run: impl FnOnce(&mut Formatter),
 ) -> String {
-    let mut printer = Printer::new((&settings).into());
     let rope = Rope::from_str(source).unwrap();
+    let mut printer = Printer::new(settings.to_printer_settings(Some(&rope)));
     let tokens = <proc_macro2::TokenStream as std::str::FromStr>::from_str(source).unwrap();
     let whitespace = crate::collect_comments::extract_whitespace_and_comments(&rope, tokens);
     let mut formatter = Formatter::with_source(settings, &mut printer, &rope, whitespace);
@@ -128,7 +128,7 @@ pub fn format_with_source(
 }
 
 pub fn format_with(settings: FormatterSettings, run: impl FnOnce(&mut Formatter)) -> String {
-    let mut printer = Printer::new((&settings).into());
+    let mut printer = Printer::new(settings.to_printer_settings(None));
     let mut formatter = Formatter::new(settings, &mut printer);
     run(&mut formatter);
     printer.eof()

--- a/formatter/src/view_macro.rs
+++ b/formatter/src/view_macro.rs
@@ -34,7 +34,7 @@ impl MacroFormatter for ViewMacroFormatter<'_> {
             return false;
         }
 
-        let Some(m) = ViewMacro::try_parse(None, mac) else {
+        let Some(m) = ViewMacro::try_parse(Default::default(), mac) else {
             return false;
         };
         let mut formatter = Formatter {

--- a/printer/src/algorithm.rs
+++ b/printer/src/algorithm.rs
@@ -50,11 +50,13 @@ pub struct PrinterSettings {
     // Target line width.
     pub margin: isize,
     // Number of spaces incement at each level of block indentation.
-    pub indent: isize,
+    pub spaces: isize,
     // Every line is allowed at least this much space, even if highly indented.
     pub min_space: isize,
     // Print CRLF line ending instead of LF
     pub crlf_line_endings: bool,
+    // Whether to use tab characters instead of spaces
+    pub hard_tabs: bool,
 }
 
 pub struct Printer {
@@ -356,7 +358,16 @@ impl Printer {
     }
 
     fn print_indent(&mut self) {
-        self.out.reserve(self.pending_indentation);
+        if !self.settings.hard_tabs {
+            self.out.reserve(self.pending_indentation);
+        } else {
+            let tabs = self.pending_indentation / self.settings.spaces as usize;
+            let remaining_spaces = self.pending_indentation % self.settings.spaces as usize;
+            self.out.reserve(tabs + remaining_spaces);
+            self.out.extend(iter::repeat('\t').take(tabs));
+            self.pending_indentation = remaining_spaces
+        }
+
         self.out
             .extend(iter::repeat(' ').take(self.pending_indentation));
         self.pending_indentation = 0;

--- a/printer/src/convenience.rs
+++ b/printer/src/convenience.rs
@@ -3,11 +3,11 @@ use std::borrow::Cow;
 
 impl Printer {
     pub fn ibox_indent(&mut self) {
-        self.ibox(self.settings.indent);
+        self.ibox(self.settings.spaces);
     }
 
     pub fn ibox_dedent(&mut self) {
-        self.ibox(-self.settings.indent);
+        self.ibox(-self.settings.spaces);
     }
 
     pub fn ibox(&mut self, indent: isize) {
@@ -18,11 +18,11 @@ impl Printer {
     }
 
     pub fn cbox_indent(&mut self) {
-        self.cbox(self.settings.indent);
+        self.cbox(self.settings.spaces);
     }
 
     pub fn cbox_dedent(&mut self) {
-        self.cbox(-self.settings.indent);
+        self.cbox(-self.settings.spaces);
     }
 
     pub fn cbox(&mut self, indent: isize) {
@@ -33,7 +33,7 @@ impl Printer {
     }
 
     pub fn end_dedent(&mut self) {
-        self.offset(-self.settings.indent);
+        self.offset(-self.settings.spaces);
         self.end();
     }
 


### PR DESCRIPTION
adds:

`leptosfmt.toml`
```toml
indentation_style = "Auto" # "Tabs", "Spaces" or "Auto"
newline_style = "Auto" # "Unix", "Windows" or "Auto"
```