### PR TITLE
Fixing new line issue

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
                 if args.check && check_if_diff(None, &original, &formatted, true) {
                     exit(1)
                 } else {
-                    println!("{formatted}")
+                    print!("{formatted}")
                 }
             }
             Err(err) => {
@@ -282,12 +282,7 @@ fn run_rustfmt(source: &str) -> Option<String> {
     let output = child.wait_with_output().expect("failed to read stdout");
 
     if output.status.success() {
-        Some(
-            std::str::from_utf8(&output.stdout)
-                .expect("stdout is not valid utf8")
-                .trim_end()
-                .to_owned(),
-        )
+        Some(String::from_utf8(output.stdout).expect("stdout is not valid utf8"))
     } else {
         None
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -282,7 +282,12 @@ fn run_rustfmt(source: &str) -> Option<String> {
     let output = child.wait_with_output().expect("failed to read stdout");
 
     if output.status.success() {
-        Some(String::from_utf8(output.stdout).expect("stdout is not valid utf8"))
+        Some(
+            std::str::from_utf8(&output.stdout)
+                .expect("stdout is not valid utf8")
+                .trim_end()
+                .to_owned(),
+        )
     } else {
         None
     }


### PR DESCRIPTION
Reading from stdin and stdout is, including newlines, for the formatted output of letposfmt as well as rustfmt. Rustfmt should already trim any empty lines at the end of a file, so this should be safe to do when reading the output and trim the ending new line.

This fixes #92 and #94 as well