### PR TITLE
Rename `ParentIdent` to `ParentIndent`

### DIFF
--- a/formatter/src/collect.rs
+++ b/formatter/src/collect.rs
@@ -5,7 +5,7 @@ use syn::{
     File, Macro,
 };
 
-use crate::{ParentIdent, ViewMacro};
+use crate::{ParentIndent, ViewMacro};
 
 struct ViewMacroVisitor<'ast> {
     macros: Vec<ViewMacro<'ast>>,
@@ -26,7 +26,7 @@ impl<'ast> Visit<'ast> for ViewMacroVisitor<'ast> {
             let tabs = indent_chars.iter().filter(|&&c| c == '\t').count();
             let spaces = indent_chars.iter().filter(|&&c| c == ' ').count();
 
-            if let Some(view_mac) = ViewMacro::try_parse(ParentIdent { tabs, spaces }, node) {
+            if let Some(view_mac) = ViewMacro::try_parse(ParentIndent { tabs, spaces }, node) {
                 self.macros.push(view_mac);
             }
         }

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -7,7 +7,7 @@ use syn::{spanned::Spanned, Macro};
 use super::{Formatter, FormatterSettings};
 
 pub struct ViewMacro<'a> {
-    pub parent_ident: ParentIdent,
+    pub parent_indent: ParentIndent,
     pub cx: Option<TokenTree>,
     pub global_class: Option<TokenTree>,
     pub nodes: Vec<Node>,
@@ -17,13 +17,13 @@ pub struct ViewMacro<'a> {
 }
 
 #[derive(Default)]
-pub struct ParentIdent {
+pub struct ParentIndent {
     pub tabs: usize,
     pub spaces: usize,
 }
 
 impl<'a> ViewMacro<'a> {
-    pub fn try_parse(parent_ident: ParentIdent, mac: &'a Macro) -> Option<Self> {
+    pub fn try_parse(parent_indent: ParentIndent, mac: &'a Macro) -> Option<Self> {
         let mut tokens = mac.tokens.clone().into_iter();
         let (cx, comma) = (tokens.next(), tokens.next());
 
@@ -56,7 +56,7 @@ impl<'a> ViewMacro<'a> {
         let nodes = rstml::parse2(tokens).ok()?;
 
         Some(Self {
-            parent_ident,
+            parent_indent,
             global_class,
             nodes,
             span,
@@ -74,7 +74,7 @@ impl<'a> ViewMacro<'a> {
 impl Formatter<'_> {
     pub fn view_macro(&mut self, view_mac: &ViewMacro) {
         let ViewMacro {
-            parent_ident: parent_indent,
+            parent_indent,
             cx,
             global_class,
             nodes,

--- a/formatter/src/formatter/mod.rs
+++ b/formatter/src/formatter/mod.rs
@@ -12,7 +12,7 @@ mod mac;
 mod node;
 
 pub use mac::format_macro;
-pub use mac::{ParentIdent, ViewMacro};
+pub use mac::{ParentIndent, ViewMacro};
 
 use serde::Deserialize;
 use serde::Serialize;


### PR DESCRIPTION
The original name appears to be a mistake