### PR TITLE
Updated readme to include neovim snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can set the `rust-analyzer.rustfmt.overrideCommand` setting.
 ```
 > Note: For VSCode users, I recommend to use workpsace settings (CMD + shift + p -> Open workspace settings), so that you can only configure `leptosfmt` for workpsaces that are using leptos. For Neovim users,
 
-Alternatively, if you are using [nvim-lspconfg](https://github.com/neovim/nvim-lspconfig), you may append the following to your `.setup{}` table:
+Alternatively, you may directly configure [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) by appending the following to your `.setup{}` table:
 ```lua
 lspconfig["rust_analyzer"].setup {
   settings = {
@@ -60,7 +60,7 @@ lspconfig["rust_analyzer"].setup {
   },
 }
 ```
-> Note: It is recommended to use [neoconf.nvim](https://github.com/folke/neoconf.nvim) for managing project-local LSP configuration.
+> Note: It is recommended to use [neoconf.nvim](https://github.com/folke/neoconf.nvim) for managing project-local LSP configuration. For more information regarding nvim-lspconfig refer the [nvim-lspconfig docs](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rust_analyzer)
 
 And **you must** configure `rustfmt` to use the correct edition, place a `rustfmt.toml` file in the root of your project:
 ```toml

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ You can set the `rust-analyzer.rustfmt.overrideCommand` setting.
 ```json
   "rust-analyzer.rustfmt.overrideCommand": ["leptosfmt", "--stdin", "--rustfmt"]
 ```
+> Note: For VSCode users, I recommend to use workpsace settings (CMD + shift + p -> Open workspace settings), so that you can only configure `leptosfmt` for workpsaces that are using leptos. For Neovim users,
+
+Alternatively, if you are using [nvim-lspconfg](https://github.com/neovim/nvim-lspconfig), you may append the following to your `.setup{}` table:
+```lua
+lspconfig["rust_analyzer"].setup {
+  settings = {
+    ["rust-analyzer"] = {
+      rustfmt = {
+        overrideCommand = { "leptosfmt", "--stdin", "--rustfmt" },
+      },
+    },
+  },
+}
+```
+> Note: It is recommended to use [neoconf.nvim](https://github.com/folke/neoconf.nvim) for managing project-local LSP configuration.
 
 And **you must** configure `rustfmt` to use the correct edition, place a `rustfmt.toml` file in the root of your project:
 ```toml
@@ -53,7 +68,6 @@ edition = "2021"
 # (optional) other config...
 ```
 
-> Note: For VSCode users, I recommend to use workpsace settings (CMD + shift + p -> Open workspace settings), so that you can only configure `leptosfmt` for workpsaces that are using leptos. For Neovim users, I recommend using [neoconf.nvim](https://github.com/folke/neoconf.nvim) for managing project-local LSP configuration.
 
 ## Configuration
 You can configure all settings through a `leptosfmt.toml` file.


### PR DESCRIPTION
added a snippet for correctly setting up nvim-lspconfig and re-structured the relevant portions of the document to make the modification cohesive. 

[ it took me a fair bit of time to set this up without Folke's neoconf, so for anyone who may need it, this will save them quite a bit of time]