### PR TITLE
Add option to override html macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Options:
   -c, --config-file <CONFIG_FILE>  Configuration file
   -s, --stdin                      Format stdin and write to stdout
   -r, --rustfmt                    Format with rustfmt after formatting with leptosfmt (requires stdin)
+      --override-macro-names 
+        <OVERRIDE_MACRO_NAMES>...  Override formatted macro names
   -q, --quiet                      
       --check                      Check if the file is correctly formatted. Exit with code 1 if not
   -h, --help                       Print help
@@ -64,6 +66,7 @@ tab_spaces = 4 # Number of spaces per tab
 indentation_style = "Auto" # "Tabs", "Spaces" or "Auto"
 newline_style = "Auto" # "Unix", "Windows" or "Auto"
 attr_value_brace_style = "WhenRequired" # "Always", "AlwaysUnlessLit", "WhenRequired" or "Preserve"
+macro_names = [ "leptos::view, view" ] # Macro names which will be formatted
 ```
 
 To see what each setting does, the see [configuration docs](./docs/configuration.md)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,9 +45,9 @@ struct Args {
     #[arg(short, long, default_value = "false", requires = "stdin")]
     rustfmt: bool,
 
-    /// Macros to be formatted.
+    /// Override formatted macro names
     #[arg(long, num_args=1.., value_delimiter= ' ')]
-    format_macros: Option<Vec<String>>,
+    override_macro_names: Option<Vec<String>>,
 
     #[arg(
         short,
@@ -110,6 +110,8 @@ fn main() {
 
                 if args.check && check_if_diff(None, &original, &formatted, true) {
                     exit(1)
+                } else {
+                    print!("{formatted}")
                 }
             }
             Err(err) => {
@@ -257,8 +259,8 @@ fn create_settings(args: &Args) -> anyhow::Result<FormatterSettings> {
         settings.tab_spaces = tab_spaces;
     }
 
-    if let Some(format_macros) = args.format_macros.to_owned() {
-        settings.format_macros = format_macros;
+    if let Some(macro_names) = args.override_macro_names.to_owned() {
+        settings.macro_names = macro_names;
     }
     Ok(settings)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,9 +45,9 @@ struct Args {
     #[arg(short, long, default_value = "false", requires = "stdin")]
     rustfmt: bool,
 
-    /// Macro to be formatted.
-    #[arg(long)]
-    html_macro: Option<String>,
+    /// Macros to be formatted.
+    #[arg(long, num_args=1.., value_delimiter= ' ')]
+    format_macros: Option<Vec<String>>,
 
     #[arg(
         short,
@@ -110,8 +110,6 @@ fn main() {
 
                 if args.check && check_if_diff(None, &original, &formatted, true) {
                     exit(1)
-                } else {
-                    print!("{formatted}")
                 }
             }
             Err(err) => {
@@ -259,8 +257,8 @@ fn create_settings(args: &Args) -> anyhow::Result<FormatterSettings> {
         settings.tab_spaces = tab_spaces;
     }
 
-    if let Some(html_macro) = args.html_macro.to_owned() {
-        settings.html_macro = html_macro;
+    if let Some(format_macros) = args.format_macros.to_owned() {
+        settings.format_macros = format_macros;
     }
     Ok(settings)
 }

--- a/formatter/src/collect.rs
+++ b/formatter/src/collect.rs
@@ -7,10 +7,10 @@ use syn::{
 
 use crate::{view_macro::get_macro_full_path, ParentIndent, ViewMacro};
 
-struct ViewMacroVisitor<'ast> {
-    macros: Vec<ViewMacro<'ast>>,
+struct ViewMacroVisitor<'a> {
+    macros: Vec<ViewMacro<'a>>,
     source: Rope,
-    macro_names: Vec<String>,
+    macro_names: &'a Vec<String>,
 }
 
 impl<'ast> Visit<'ast> for ViewMacroVisitor<'ast> {
@@ -41,11 +41,11 @@ impl<'ast> Visit<'ast> for ViewMacroVisitor<'ast> {
     }
 }
 
-pub fn collect_macros_in_file(
-    file: &File,
+pub fn collect_macros_in_file<'a>(
+    file: &'a File,
     source: Rope,
-    macro_names: Vec<String>,
-) -> (Rope, Vec<ViewMacro<'_>>) {
+    macro_names: &'a Vec<String>,
+) -> (Rope, Vec<ViewMacro<'a>>) {
     let mut visitor = ViewMacroVisitor {
         source,
         macros: Vec::new(),

--- a/formatter/src/collect.rs
+++ b/formatter/src/collect.rs
@@ -10,11 +10,12 @@ use crate::{ParentIndent, ViewMacro};
 struct ViewMacroVisitor<'ast> {
     macros: Vec<ViewMacro<'ast>>,
     source: Rope,
+    html_macro: String,
 }
 
 impl<'ast> Visit<'ast> for ViewMacroVisitor<'ast> {
     fn visit_macro(&mut self, node: &'ast Macro) {
-        if node.path.is_ident("view") {
+        if node.path.is_ident(&self.html_macro) {
             let span_line = node.span().start().line;
             let line = self.source.line(span_line - 1);
 
@@ -35,10 +36,15 @@ impl<'ast> Visit<'ast> for ViewMacroVisitor<'ast> {
     }
 }
 
-pub fn collect_macros_in_file(file: &File, source: Rope) -> (Rope, Vec<ViewMacro<'_>>) {
+pub fn collect_macros_in_file(
+    file: &File,
+    source: Rope,
+    html_macro: String,
+) -> (Rope, Vec<ViewMacro<'_>>) {
     let mut visitor = ViewMacroVisitor {
         source,
         macros: Vec::new(),
+        html_macro,
     };
 
     visitor.visit_file(file);

--- a/formatter/src/formatter/element.rs
+++ b/formatter/src/formatter/element.rs
@@ -62,7 +62,7 @@ impl Formatter<'_> {
         }
     }
 
-    pub fn children(&mut self, children: &Vec<Node>, attribute_count: usize) {
+    pub fn children(&mut self, children: &[Node], attribute_count: usize) {
         if children.is_empty() {
             return;
         }

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -85,7 +85,8 @@ impl Formatter<'_> {
             .cbox((parent_indent.tabs * self.settings.tab_spaces + parent_indent.spaces) as isize);
 
         self.flush_comments(cx.span().start().line - 1);
-        self.printer.word("view! {");
+        let macro_word = format!("{}! {{", self.settings.html_macro);
+        self.printer.word(macro_word);
 
         if let Some(cx) = cx {
             self.printer.word(" ");
@@ -170,9 +171,9 @@ pub fn format_macro(
                 mac.mac.tokens.clone(),
             );
 
-            Formatter::with_source(*settings, &mut printer, source, whitespace)
+            Formatter::with_source(settings, &mut printer, source, whitespace)
         }
-        None => Formatter::new(*settings, &mut printer),
+        None => Formatter::new(settings, &mut printer),
     };
 
     formatter.view_macro(mac);

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -14,6 +14,7 @@ pub struct ViewMacro<'a> {
     pub span: Span,
     pub mac: &'a Macro,
     pub comma: Option<TokenTree>,
+    pub format_macro: String,
 }
 
 #[derive(Default)]
@@ -23,7 +24,11 @@ pub struct ParentIndent {
 }
 
 impl<'a> ViewMacro<'a> {
-    pub fn try_parse(parent_indent: ParentIndent, mac: &'a Macro) -> Option<Self> {
+    pub fn try_parse(
+        parent_indent: ParentIndent,
+        mac: &'a Macro,
+        format_macro: String,
+    ) -> Option<Self> {
         let mut tokens = mac.tokens.clone().into_iter();
         let (cx, comma) = (tokens.next(), tokens.next());
 
@@ -63,6 +68,7 @@ impl<'a> ViewMacro<'a> {
             mac,
             cx,
             comma,
+            format_macro,
         })
     }
 
@@ -85,7 +91,7 @@ impl Formatter<'_> {
             .cbox((parent_indent.tabs * self.settings.tab_spaces + parent_indent.spaces) as isize);
 
         self.flush_comments(cx.span().start().line - 1);
-        let macro_word = format!("{}! {{", self.settings.html_macro);
+        let macro_word = format!("{}! {{", view_mac.format_macro);
         self.printer.word(macro_word);
 
         if let Some(cx) = cx {
@@ -190,7 +196,7 @@ mod tests {
     macro_rules! view_macro {
         ($($tt:tt)*) => {{
             let mac: Macro = syn::parse2(quote! { $($tt)* }).unwrap();
-            format_macro(&ViewMacro::try_parse(Default::default(), &mac).unwrap(), &Default::default(), None)
+            format_macro(&ViewMacro::try_parse(Default::default(), &mac, "view".to_string()).unwrap(), &Default::default(), None)
         }}
     }
 

--- a/formatter/src/formatter/mod.rs
+++ b/formatter/src/formatter/mod.rs
@@ -40,7 +40,7 @@ pub enum NewlineStyle {
     Windows,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct FormatterSettings {
     // Maximum width of each line
@@ -57,6 +57,9 @@ pub struct FormatterSettings {
 
     // Determines placement of braces around single expression attribute values
     pub attr_value_brace_style: AttributeValueBraceStyle,
+
+    // Determines macro to be formatted
+    pub html_macro: String,
 }
 
 impl Default for FormatterSettings {
@@ -67,6 +70,7 @@ impl Default for FormatterSettings {
             attr_value_brace_style: AttributeValueBraceStyle::WhenRequired,
             indentation_style: IndentationStyle::Auto,
             newline_style: NewlineStyle::Auto,
+            html_macro: "view".to_string(),
         }
     }
 }
@@ -110,14 +114,14 @@ impl FormatterSettings {
 
 pub struct Formatter<'a> {
     pub printer: &'a mut leptosfmt_pretty_printer::Printer,
-    pub settings: FormatterSettings,
+    pub settings: &'a FormatterSettings,
     pub(crate) source: Option<&'a Rope>,
     pub(crate) whitespace_and_comments: HashMap<usize, Option<String>>,
     pub(crate) line_offset: Option<usize>,
 }
 
 impl<'a> Formatter<'a> {
-    pub fn new(settings: FormatterSettings, printer: &'a mut Printer) -> Self {
+    pub fn new(settings: &'a FormatterSettings, printer: &'a mut Printer) -> Self {
         Self {
             printer,
             settings,
@@ -127,7 +131,7 @@ impl<'a> Formatter<'a> {
         }
     }
     pub fn with_source(
-        settings: FormatterSettings,
+        settings: &'a FormatterSettings,
         printer: &'a mut Printer,
         source: &'a Rope,
         comments: HashMap<usize, Option<String>>,
@@ -184,4 +188,3 @@ impl<'a> Formatter<'a> {
         self.line_offset = Some(line_index);
     }
 }
-

--- a/formatter/src/formatter/mod.rs
+++ b/formatter/src/formatter/mod.rs
@@ -58,8 +58,8 @@ pub struct FormatterSettings {
     // Determines placement of braces around single expression attribute values
     pub attr_value_brace_style: AttributeValueBraceStyle,
 
-    // Determines macros to be formatted
-    pub format_macros: Vec<String>,
+    // Determines macros to be formatted. Default: leptos::view, view
+    pub macro_names: Vec<String>,
 }
 
 impl Default for FormatterSettings {
@@ -70,7 +70,7 @@ impl Default for FormatterSettings {
             attr_value_brace_style: AttributeValueBraceStyle::WhenRequired,
             indentation_style: IndentationStyle::Auto,
             newline_style: NewlineStyle::Auto,
-            format_macros: vec!["leptos::view".to_string(), "view".to_string()],
+            macro_names: vec!["leptos::view".to_string(), "view".to_string()],
         }
     }
 }

--- a/formatter/src/formatter/mod.rs
+++ b/formatter/src/formatter/mod.rs
@@ -58,8 +58,8 @@ pub struct FormatterSettings {
     // Determines placement of braces around single expression attribute values
     pub attr_value_brace_style: AttributeValueBraceStyle,
 
-    // Determines macro to be formatted
-    pub html_macro: String,
+    // Determines macros to be formatted
+    pub format_macros: Vec<String>,
 }
 
 impl Default for FormatterSettings {
@@ -70,7 +70,7 @@ impl Default for FormatterSettings {
             attr_value_brace_style: AttributeValueBraceStyle::WhenRequired,
             indentation_style: IndentationStyle::Auto,
             newline_style: NewlineStyle::Auto,
-            html_macro: "view".to_string(),
+            format_macros: vec!["leptos::view".to_string(), "view".to_string()],
         }
     }
 }

--- a/formatter/src/lib.rs
+++ b/formatter/src/lib.rs
@@ -20,7 +20,7 @@ pub use formatter::*;
 
 pub fn format_file(path: &Path, settings: FormatterSettings) -> Result<String, FormatError> {
     let file = std::fs::read_to_string(path)?;
-    format_file_source(&file, settings)
+    format_file_source(&file, &settings)
 }
 
 fn get_text_beween_spans(rope: &Rope, start: LineColumn, end: LineColumn) -> RopeSlice<'_> {

--- a/formatter/src/source_file.rs
+++ b/formatter/src/source_file.rs
@@ -33,8 +33,8 @@ pub fn format_file_source(
     settings: &FormatterSettings,
 ) -> Result<String, FormatError> {
     let ast = syn::parse_file(source)?;
-    let rope = Rope::try_from(source).unwrap();
-    let (mut rope, macros) = collect_macros_in_file(&ast, rope, settings.html_macro.to_owned());
+    let rope = Rope::from(source);
+    let (mut rope, macros) = collect_macros_in_file(&ast, rope, settings.format_macros.to_owned());
     format_source(&mut rope, macros, settings)
 }
 
@@ -51,7 +51,7 @@ fn format_source(
         let end = mac.delimiter.span().close().end();
         let start_byte = line_column_to_byte(source, start);
         let end_byte = line_column_to_byte(source, end);
-        let new_text = format_macro(&view_mac, &settings, Some(source));
+        let new_text = format_macro(&view_mac, settings, Some(source));
 
         edits.push(TextEdit {
             range: start_byte..end_byte,
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    fn override_html_macro() {
+    fn override_format_macros() {
         let source = indoc! {r#"
             fn main() {
                 html! {   cx ,  <div>  <span>{
@@ -154,7 +154,7 @@ mod tests {
         let result = format_file_source(
             source,
             &FormatterSettings {
-                html_macro: "html".to_string(),
+                format_macros: vec!["html".to_string()],
                 ..Default::default()
             },
         )

--- a/formatter/src/source_file.rs
+++ b/formatter/src/source_file.rs
@@ -34,7 +34,7 @@ pub fn format_file_source(
 ) -> Result<String, FormatError> {
     let ast = syn::parse_file(source)?;
     let rope = Rope::from(source);
-    let (mut rope, macros) = collect_macros_in_file(&ast, rope, settings.macro_names.to_owned());
+    let (mut rope, macros) = collect_macros_in_file(&ast, rope, &settings.macro_names);
     format_source(&mut rope, macros, settings)
 }
 

--- a/formatter/src/test_helpers.rs
+++ b/formatter/src/test_helpers.rs
@@ -122,14 +122,14 @@ pub fn format_with_source(
     let mut printer = Printer::new(settings.to_printer_settings(Some(&rope)));
     let tokens = <proc_macro2::TokenStream as std::str::FromStr>::from_str(source).unwrap();
     let whitespace = crate::collect_comments::extract_whitespace_and_comments(&rope, tokens);
-    let mut formatter = Formatter::with_source(settings, &mut printer, &rope, whitespace);
+    let mut formatter = Formatter::with_source(&settings, &mut printer, &rope, whitespace);
     run(&mut formatter);
     printer.eof()
 }
 
 pub fn format_with(settings: FormatterSettings, run: impl FnOnce(&mut Formatter)) -> String {
     let mut printer = Printer::new(settings.to_printer_settings(None));
-    let mut formatter = Formatter::new(settings, &mut printer);
+    let mut formatter = Formatter::new(&settings, &mut printer);
     run(&mut formatter);
     printer.eof()
 }

--- a/formatter/src/view_macro.rs
+++ b/formatter/src/view_macro.rs
@@ -28,15 +28,25 @@ impl ViewMacroFormatter<'_> {
     }
 }
 
+pub fn get_macro_full_path(mac: &syn::Macro) -> String {
+    mac.path
+        .segments
+        .iter()
+        .map(|path| path.ident.to_string())
+        .collect::<Vec<String>>()
+        .join("::")
+}
+
 impl MacroFormatter for ViewMacroFormatter<'_> {
     fn format(&self, printer: &mut leptosfmt_pretty_printer::Printer, mac: &syn::Macro) -> bool {
-        for format_macro in &self.settings.format_macros {
-            if !mac.path.is_ident(&format_macro) {
+        let mut formatted = false;
+
+        for macro_name in &self.settings.macro_names {
+            if &get_macro_full_path(mac) != macro_name {
                 continue;
             }
 
-            let Some(m) = ViewMacro::try_parse(Default::default(), mac, format_macro.to_owned())
-            else {
+            let Some(m) = ViewMacro::try_parse(Default::default(), mac) else {
                 continue;
             };
             let mut formatter = Formatter {
@@ -48,8 +58,9 @@ impl MacroFormatter for ViewMacroFormatter<'_> {
             };
 
             formatter.view_macro(&m);
+            formatted = true;
         }
 
-        true
+        formatted
     }
 }

--- a/formatter/src/view_macro.rs
+++ b/formatter/src/view_macro.rs
@@ -30,22 +30,26 @@ impl ViewMacroFormatter<'_> {
 
 impl MacroFormatter for ViewMacroFormatter<'_> {
     fn format(&self, printer: &mut leptosfmt_pretty_printer::Printer, mac: &syn::Macro) -> bool {
-        if !mac.path.is_ident(&self.settings.html_macro) {
-            return false;
+        for format_macro in &self.settings.format_macros {
+            if !mac.path.is_ident(&format_macro) {
+                continue;
+            }
+
+            let Some(m) = ViewMacro::try_parse(Default::default(), mac, format_macro.to_owned())
+            else {
+                continue;
+            };
+            let mut formatter = Formatter {
+                printer,
+                settings: self.settings,
+                source: self.source,
+                line_offset: self.line_offset,
+                whitespace_and_comments: self.comments.clone(),
+            };
+
+            formatter.view_macro(&m);
         }
 
-        let Some(m) = ViewMacro::try_parse(Default::default(), mac) else {
-            return false;
-        };
-        let mut formatter = Formatter {
-            printer,
-            settings: &self.settings,
-            source: self.source,
-            line_offset: self.line_offset,
-            whitespace_and_comments: self.comments.clone(),
-        };
-
-        formatter.view_macro(&m);
         true
     }
 }

--- a/formatter/src/view_macro.rs
+++ b/formatter/src/view_macro.rs
@@ -6,19 +6,19 @@ use leptosfmt_prettyplease::MacroFormatter;
 use crate::{Formatter, FormatterSettings, ViewMacro};
 
 pub struct ViewMacroFormatter<'a> {
-    settings: FormatterSettings,
+    settings: &'a FormatterSettings,
     source: Option<&'a Rope>,
     line_offset: Option<usize>,
     comments: HashMap<usize, Option<String>>,
 }
 
 impl ViewMacroFormatter<'_> {
-    pub fn new(
-        settings: FormatterSettings,
-        source: Option<&Rope>,
+    pub fn new<'a>(
+        settings: &'a FormatterSettings,
+        source: Option<&'a Rope>,
         line_offset: Option<usize>,
         comments: HashMap<usize, Option<String>>,
-    ) -> ViewMacroFormatter<'_> {
+    ) -> ViewMacroFormatter<'a> {
         ViewMacroFormatter {
             settings,
             source,
@@ -30,7 +30,7 @@ impl ViewMacroFormatter<'_> {
 
 impl MacroFormatter for ViewMacroFormatter<'_> {
     fn format(&self, printer: &mut leptosfmt_pretty_printer::Printer, mac: &syn::Macro) -> bool {
-        if !mac.path.is_ident("view") {
+        if !mac.path.is_ident(&self.settings.html_macro) {
             return false;
         }
 
@@ -39,7 +39,7 @@ impl MacroFormatter for ViewMacroFormatter<'_> {
         };
         let mut formatter = Formatter {
             printer,
-            settings: self.settings,
+            settings: &self.settings,
             source: self.source,
             line_offset: self.line_offset,
             whitespace_and_comments: self.comments.clone(),


### PR DESCRIPTION
Closes #17 and to some extend #98

I am quite new to rust and i am not sure this would be the best way to achieve this, since I had to change settings to be references. 

You can now override the view macro name in the cli and in settings.
This allows for aliasing the macro, or use with plain rstml macro.