### PR TITLE
feat: add exclude patterns support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leptosfmt"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "leptosfmt-formatter"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "crop",
  "indoc",
@@ -324,11 +324,11 @@ dependencies = [
 
 [[package]]
 name = "leptosfmt-pretty-printer"
-version = "0.1.19"
+version = "0.1.20"
 
 [[package]]
 name = "leptosfmt-prettyplease"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "indoc",
  "leptosfmt-pretty-printer",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Options:
           Maximum width of each line
   -t, --tab-spaces <TAB_SPACES>
           Number of spaces per tab
+  -x, --excludes <EXCLUDE_PATTERNS>
+          A space separated list of file or directory
   -c, --config-file <CONFIG_FILE>
           Configuration file
   -s, --stdin


### PR DESCRIPTION
### Description

This PR enhances the `leptosfmt` command to support excluding files or directories.

### Usage

In my case, I need to exclude just one directory out of 5 directories, so instead of including specific directories, I simply use the `exclude` feature :

```bash
leptosfmt src/ -x src/first -x src/secundo/mod.rs
```

### Changes

- added `--exclude (-x)` argument
- updated `get_file_paths` function.

I hope this feature is useful to everyone.
