### PR TITLE
fix: use 'tab_spaces' for size of hard tabs instead of hardcoded 4

### DIFF
--- a/printer/src/algorithm.rs
+++ b/printer/src/algorithm.rs
@@ -360,16 +360,15 @@ impl Printer {
     fn print_indent(&mut self) {
         if !self.settings.hard_tabs {
             self.out.reserve(self.pending_indentation);
+            self.out
+                .extend(iter::repeat(' ').take(self.pending_indentation));
         } else {
-            let tabs = self.pending_indentation / 4;
-            let remaining_spaces = self.pending_indentation % 4;
+            let tabs = self.pending_indentation / self.settings.tab_spaces as usize;
+            let remaining_spaces = self.pending_indentation % self.settings.tab_spaces as usize;
             self.out.reserve(tabs + remaining_spaces);
             self.out.extend(iter::repeat('\t').take(tabs));
-            self.pending_indentation = remaining_spaces
+            self.out.extend(iter::repeat(' ').take(remaining_spaces));
         }
-
-        self.out
-            .extend(iter::repeat(' ').take(self.pending_indentation));
         self.pending_indentation = 0;
     }
 }

--- a/printer/src/algorithm.rs
+++ b/printer/src/algorithm.rs
@@ -359,8 +359,9 @@ impl Printer {
 
     fn print_indent(&mut self) {
         let (tabs, spaces) = if self.settings.hard_tabs {
-            // Note: we have to print the remainder in spaces, as pending_indentation consint of _any_ breakable token
+            // Note: we have to print the remainder in spaces, as pending_indentation represents the space of _any_ breakable token
             // including break tokens with never_break set to 'true', meaning that indentation (e.g. a single space) can be printed in the middle of a line as well.
+            // see `print_break` for implementation details
             let tabs = self.pending_indentation / self.settings.tab_spaces as usize;
             let remainder = self.pending_indentation % self.settings.tab_spaces as usize;
             (tabs, remainder)

--- a/printer/src/algorithm.rs
+++ b/printer/src/algorithm.rs
@@ -358,17 +358,19 @@ impl Printer {
     }
 
     fn print_indent(&mut self) {
-        if !self.settings.hard_tabs {
-            self.out.reserve(self.pending_indentation);
-            self.out
-                .extend(iter::repeat(' ').take(self.pending_indentation));
-        } else {
+        let (tabs, spaces) = if self.settings.hard_tabs {
+            // Note: we have to print the remainder in spaces, as pending_indentation does not only consist of tabs,
+            // but blank space of any inconsistent break, which could be a single space too, see `print_break` for implementation details.
             let tabs = self.pending_indentation / self.settings.tab_spaces as usize;
-            let remaining_spaces = self.pending_indentation % self.settings.tab_spaces as usize;
-            self.out.reserve(tabs + remaining_spaces);
-            self.out.extend(iter::repeat('\t').take(tabs));
-            self.out.extend(iter::repeat(' ').take(remaining_spaces));
-        }
+            let remainder = self.pending_indentation % self.settings.tab_spaces as usize;
+            (tabs, remainder)
+        } else {
+            (0, self.pending_indentation)
+        };
+
+        self.out.reserve(tabs + spaces);
+        self.out.extend(iter::repeat('\t').take(tabs));
+        self.out.extend(iter::repeat(' ').take(spaces));
         self.pending_indentation = 0;
     }
 }

--- a/printer/src/algorithm.rs
+++ b/printer/src/algorithm.rs
@@ -359,8 +359,8 @@ impl Printer {
 
     fn print_indent(&mut self) {
         let (tabs, spaces) = if self.settings.hard_tabs {
-            // Note: we have to print the remainder in spaces, as pending_indentation does not only consist of tabs,
-            // but blank space of any inconsistent break, which could be a single space too, see `print_break` for implementation details.
+            // Note: we have to print the remainder in spaces, as pending_indentation consint of _any_ breakable token
+            // including break tokens with never_break set to 'true', meaning that indentation (e.g. a single space) can be printed in the middle of a line as well.
             let tabs = self.pending_indentation / self.settings.tab_spaces as usize;
             let remainder = self.pending_indentation % self.settings.tab_spaces as usize;
             (tabs, remainder)


### PR DESCRIPTION
resolves #140 