### PR TITLE
fix: remove trailing space after doctype closing tag

### DIFF
--- a/formatter/src/formatter/node.rs
+++ b/formatter/src/formatter/node.rs
@@ -27,7 +27,7 @@ impl Formatter<'_> {
     pub fn doctype(&mut self, doctype: &NodeDoctype) {
         self.printer.word("<!DOCTYPE ");
         self.raw_text(&doctype.value, false);
-        self.printer.word("> ");
+        self.printer.word(">");
     }
 
     pub fn node_text(&mut self, text: &NodeText) {


### PR DESCRIPTION
resolves #146 