### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: leptosfmt
+  name: leptosfmt
+  description: Format leptos view! macro
+  language: docker
+  entry: /leptosfmt
+  args: []
+  types: [file, rust]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.81.0-alpine AS build
+
+RUN apk add --no-cache musl-dev~=1.2
+
+COPY . /app
+WORKDIR /app
+RUN cargo build --package leptosfmt \
+                --target x86_64-unknown-linux-musl \
+                --locked \
+                --release
+
+FROM scratch
+COPY --from=build /app/target/x86_64-unknown-linux-musl/release/leptosfmt /leptosfmt
+ENTRYPOINT ["/leptosfmt"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ edition = "2021"
   For Emacs users, see the relevant [configuration option](https://emacs-lsp.github.io/lsp-mode/page/lsp-rust-analyzer/#lsp-rust-analyzer-rustfmt-override-command) for LSP Mode.
 </details>
 
+## Pre-Commit
+You can run leptosfmt as a git hook using [pre-commit](https://pre-commit.com):
+
+```yaml
+- repo: https://github.com/bram209/leptosfmt
+  rev: <branch, tag or commit>
+  hooks:
+    - id: leptosfmt
+      stages: ["pre-commit"]
+```
+
 ## Configuration
 
 You can configure all settings through a `leptosfmt.toml` file.


### PR DESCRIPTION
Hi, thanks for making leptosfmt!

I usually like formatters in pre-commit hooks in addition to editors, rather than in CI. This PR enables that for leptosfmt using the [pre-commit](https://pre-commit.com) framework. 

Pre-commit doesn't allow building workspace rust projects, which severely limits the usability of the `rust` type. The usual workaround (as seen in [this issue](https://github.com/pre-commit/pre-commit/issues/2931)) is to just use a `docker` type. So I also added a `Dockerfile` that builds and runs leptosfmt which I hope can be useful for more than just pre-commit.

I also added a very short section to the readme with usage instructions.

I`m happy to follow up with any required changes