### PR TITLE
fix: formatting of empty tags with prop spreading (#151)

### DIFF
--- a/formatter/src/formatter/attribute.rs
+++ b/formatter/src/formatter/attribute.rs
@@ -225,4 +225,16 @@ mod tests {
         let f = format_attribute! {   let(Item { name, value })  };
         assert_snapshot!(f, @r#"let(Item { name, value })"#)
     }
+
+    #[test]
+    fn prop_spreading_unnamed() {
+        let f = format_attribute! {  {..}  };
+        assert_snapshot!(f, @r#"{..}"#)
+    }
+
+    #[test]
+    fn prop_spreading_named() {
+        let f = format_attribute! {  { ..some_props }  };
+        assert_snapshot!(f, @r#"{..some_props}"#)
+    }
 }

--- a/formatter/src/formatter/mac.rs
+++ b/formatter/src/formatter/mac.rs
@@ -257,4 +257,16 @@ mod tests {
         }
         "#);
     }
+
+    #[test]
+    fn unnamed_element_empty_props_spreading() {
+        let formatted = view_macro!(view! { <{..} class="foo" /> });
+        insta::assert_snapshot!(formatted, @r#"view! { <{..} class="foo" /> }"#);
+    }
+
+    #[test]
+    fn unnamed_element_named_props_spreading() {
+        let formatted = view_macro!(view! { <{..some_props} class="foo" /> });
+        insta::assert_snapshot!(formatted, @r#"view! { <{..some_props} class="foo" /> }"#);
+    }
 }

--- a/formatter/src/formatter/node.rs
+++ b/formatter/src/formatter/node.rs
@@ -51,7 +51,11 @@ impl Formatter<'_> {
     }
 
     pub fn node_name(&mut self, name: &NodeName) {
-        self.printer.word(name.to_string());
+        if let NodeName::Block(block) = name {
+            self.node_value_block_expr(block, false, false);
+        } else {
+            self.printer.word(name.to_string());
+        }
     }
 
     pub fn node_block(&mut self, block: &NodeBlock) {


### PR DESCRIPTION
This commit addresses the issue where leptosfmt incorrectly removed the '..' from empty tags with prop spreading, causing compilation errors. The formatter now correctly preserves the '..' in expressions like `<{..} class="foo" />.`

Fixes #151