### PR TITLE
Pin `rustywind-core` version to avoid breaking change

### DIFF
--- a/formatter/Cargo.toml
+++ b/formatter/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0.61"
 crop = "0.3.0"
 serde = { version = "1.0.203", features = ["derive"] }
 quote = "1.0.36"
-rustywind_core = "0.1.2"
+rustywind_core = "= 0.1.2"
 
 [dev-dependencies]
 indoc = "2.0.5"


### PR DESCRIPTION
Version 0.1.4 of rustwind-core introduced a breaking change:

```
error[E0063]: missing field `class_wrapping` in initializer of `Options`
 --> /.../registry/src/index.crates.io-6f17d22bba15001f/leptosfmt-formatter-0.1.32/src/formatter/tailwind.rs:7:43
  |
7 |         static OPTIONS: sorter::Options = sorter::Options {
  |                                           ^^^^^^^^^^^^^^^ missing `class_wrapping`

For more information about this error, try `rustc --explain E0063`.
```

This change should prevent Cargo from trying to use it.