### PR TITLE
feat: add `+nightly` option for `rustfmt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Options:
           Format stdin and write to stdout
   -r, --rustfmt
           Format with rustfmt after formatting with leptosfmt (requires stdin)
-  -n, --nightly
-          Use rustfmt nightly after formatting with leptosfmt (requires rustfmt)
+      --rustfmt-args "<RUSTFMT_ARGS>..."
+          Pass additional arguments to `rustfmt` (requires `rustfmt`)
       --override-macro-names <OVERRIDE_MACRO_NAMES>...
           Override formatted macro names
   -e, --experimental-tailwind

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Options:
           Format stdin and write to stdout
   -r, --rustfmt
           Format with rustfmt after formatting with leptosfmt (requires stdin)
+  -n, --nightly
+          Use rustfmt nightly after formatting with leptosfmt (requires rustfmt)
       --override-macro-names <OVERRIDE_MACRO_NAMES>...
           Override formatted macro names
   -e, --experimental-tailwind
@@ -72,37 +74,37 @@ edition = "2021"
 <details>
   <summary>Option 1: Using `rust-analyzer.toml` (Recommended)</summary> <br />
   A new way to configure `rust-analyzer` to use `leptosfmt` is to use directory based `rust-analyzer` configuration.
-  
-  To do this, create a file named `rust-analyzer.toml` in the root of your project with the following content: 
+
+  To do this, create a file named `rust-analyzer.toml` in the root of your project with the following content:
   ```toml
-  [rustfmt] 
+  [rustfmt]
   overrideCommand = ["leptosfmt", "--stdin", "--rustfmt"]
   # (optional) other config...
   ```
-  
+
   This method of setting up rust-analyzer is editor agnostic to any editor that uses `rust-analyzer` for formatting rust code.
-  
+
   > Note: This feature of `rust-analyzer` is currently unstable and no guarantees are made that this will continue to work across versions. You have to use a recent version of `rust-analyzer` ([2024-06-10](https://github.com/rust-lang/rust-analyzer/releases/tag/2024-06-10) or newer).
 </details>
 
 <details>
   <summary>Option 2: Editor specific config</summary> <br />
-  
+
   **VSCode**:
-  
+
   For VSCode users, I recommend to use workpsace settings (CMD + shift + p -> Open workspace settings), so that you can only configure `leptosfmt` for workspaces that are using leptos.
-  
+
   Open your workspace settings and add the following configuration:
   ```json
   {
     "rust-analyzer.rustfmt.overrideCommand": ["leptosfmt", "--stdin", "--rustfmt"]
   }
   ```
-  
+
   **Neovim**:
-  
+
   For Neovim users, I recommend using [neoconf.nvim](https://github.com/folke/neoconf.nvim) for managing project-local LSP configuration, so that you can only configure `leptosfmt` for workspaces that are using leptos.
-  
+
   Alternatively, you may directly configure [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) by appending the following to your `.setup{}` table:
   ```lua
   lspconfig["rust_analyzer"].setup {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,6 +49,10 @@ struct Args {
     #[arg(short, long, default_value = "false", requires = "stdin")]
     rustfmt: bool,
 
+    /// Use `rustfmt` with `+nightly` features (requires `rustfmt`)
+    #[arg(short, long, default_value = "false", requires = "rustfmt")]
+    nightly: bool,
+
     /// Override formatted macro names
     #[arg(long, num_args=1.., value_delimiter= ' ')]
     override_macro_names: Option<Vec<String>>,
@@ -117,7 +121,7 @@ fn main() {
                 mut formatted,
             }) => {
                 if args.rustfmt {
-                    formatted = run_rustfmt(&formatted).unwrap_or(formatted);
+                    formatted = run_rustfmt(&formatted, args.nightly).unwrap_or(formatted);
                 }
 
                 if args.check && check_if_diff(None, &original, &formatted, true) {
@@ -318,8 +322,11 @@ fn load_config(path: &PathBuf) -> anyhow::Result<FormatterSettings> {
         .with_context(|| format!("failed to load config file: {}", path.display()))
 }
 
-fn run_rustfmt(source: &str) -> Option<String> {
+fn run_rustfmt(source: &str, nightly: bool) -> Option<String> {
+    let args = if nightly { vec!["+nightly"] } else { vec![] };
+
     let mut child = process::Command::new("rustfmt")
+        .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,9 +49,9 @@ struct Args {
     #[arg(short, long, default_value = "false", requires = "stdin")]
     rustfmt: bool,
 
-    /// Use `rustfmt` with `+nightly` features (requires `rustfmt`)
-    #[arg(short, long, default_value = "false", requires = "rustfmt")]
-    nightly: bool,
+    /// Pass additional arguments to `rustfmt` (requires `rustfmt`)
+    #[arg(long, default_value = "", value_delimiter = ' ', requires = "rustfmt")]
+    rustfmt_args: Vec<String>,
 
     /// Override formatted macro names
     #[arg(long, num_args=1.., value_delimiter= ' ')]
@@ -121,7 +121,7 @@ fn main() {
                 mut formatted,
             }) => {
                 if args.rustfmt {
-                    formatted = run_rustfmt(&formatted, args.nightly).unwrap_or(formatted);
+                    formatted = run_rustfmt(&formatted, &args.rustfmt_args).unwrap_or(formatted);
                 }
 
                 if args.check && check_if_diff(None, &original, &formatted, true) {
@@ -322,11 +322,9 @@ fn load_config(path: &PathBuf) -> anyhow::Result<FormatterSettings> {
         .with_context(|| format!("failed to load config file: {}", path.display()))
 }
 
-fn run_rustfmt(source: &str, nightly: bool) -> Option<String> {
-    let args = if nightly { vec!["+nightly"] } else { vec![] };
-
+fn run_rustfmt(source: &str, args: &[String]) -> Option<String> {
     let mut child = process::Command::new("rustfmt")
-        .args(&args)
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION
### Description

This update introduces a new command-line argument `--rustfmt-args` to enable rustfmt with additional args like `+nightly` when using leptosfmt. The `run_rustfmt` function has been modified to accept this new argument, allowing for more flexible formatting options.

Currently no tests have been added. I can do so but it would require additional code changes to allow for ensuring the environment supports nightly rustfmt. Let me know if this would be desired. 

Fixes #173